### PR TITLE
Updated draggable home button addon revision.

### DIFF
--- a/app/apps.json
+++ b/app/apps.json
@@ -254,7 +254,7 @@
       "author": "Eddie Lin",
       "type": "addon",
       "url": "https://github.com/elin-moco/fxos-addon-draggable-home-btn",
-      "revision": "b556985d5dac8144b38b9daff810113e8276ff8c"
+      "revision": "db613b12ade2addd536611135ef715d71b219c11"
     },
     "https://elin-moco.github.io/fxos-addon-yellow-mask/manifest.webapp": {
       "manifestURL": "https://elin-moco.github.io/fxos-addon-yellow-mask/manifest.webapp",


### PR DESCRIPTION
There are 3 changes this time:
1. Enable/disable software home button according to addon state
2. Detect edge to avoid button being dragged out of screen
3. Momentum and bounce effect
